### PR TITLE
Stop inserting extra quotes around gem name

### DIFF
--- a/backends/rubygems.py
+++ b/backends/rubygems.py
@@ -26,7 +26,7 @@ class CoprRubygems(CoprBackend):
             self.conf["copr-config"],
             "buildgem",
             self.copr_full_name,
-            "--gem", "'{0}'".format(package.name),
+            "--gem={0}".format(package.name),
             "--nowait",
             "--background"
         ]


### PR DESCRIPTION
Otherwise every build fails because of non-existing Gem name, e.g.

    Running: gem2rpm ''"'"'skates'"'"'' --srpm -C /var/lib/copr-rpmbuild/results --fetch
    cmd: ['gem2rpm', "'skates'", '--srpm', '-C', '/var/lib/copr-rpmbuild/results', '--fetch']
    Copr build error: Gem fetch failed with error: 404 Not Found